### PR TITLE
Improve Stratego bot interface

### DIFF
--- a/bot_vs_bot.py
+++ b/bot_vs_bot.py
@@ -1,0 +1,16 @@
+from stratego import StrategoConfig, GameMode
+
+from bot_arena.bot_controller import BotController
+from bot_arena.game_manager import GameManager
+
+red_bot = BotController("lib/stratego_evaluator/agents/basic_cpp/basic_cpp", "RedBot")
+blue_bot = BotController("lib/stratego_evaluator/agents/basic_cpp/basic_cpp", "BlueBot")
+
+game_manager = GameManager(
+    config=StrategoConfig.from_game_mode(GameMode.ORIGINAL),
+    red_bot=red_bot,
+    blue_bot=blue_bot,
+    render_mode=None,
+)
+
+game_manager.run()


### PR DESCRIPTION
## Summary
- rewrite bot controller for line-based protocol and timeout handling
- adjust game manager to use new bot controller interface
- add script `bot_vs_bot.py` to run two bots against each other

## Testing
- `make -C lib/stratego_evaluator/agents/basic_cpp`
- `PYTHONPATH=src python3 bot_vs_bot.py` *(fails: BrokenPipeError)*


------
https://chatgpt.com/codex/tasks/task_e_68476bfa398083308dc76b9f4bd7854f